### PR TITLE
Merged two WooCommerce panels within the customizer sidebar.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,80 +1,93 @@
 # Change log
 
+## [[1.3.5]]
+
+### Changed
+
+- Merged two WooCommerce panels within the customizer sidebar.
+
 ## [[1.3.4]]() - 2020-05-21
 
 ### Added
+
 - Woocommerce checkout and cart styling improved.
 - Adding in the customizer colour for the accordian block.
 
 ### Fixed
+
 - Fixed the My Account menu slug not calling the correct page ID.
 - Fixing the my account menu translations.
 
 ### Security
+
 - General testing to ensure compatibility with latest WordPress version (5.4.1).
 - General testing to ensure compatibility with latest LSX Theme version (2.8).
-
 
 ## [[1.3.3]](https://github.com/lightspeeddevelopment/lsx-customizer/releases/tag/1.3.3) - 2020-03-30
 
 ### Fixed
+
 - Moved the un-prefixed `custom_login_url()` function into a class.
 - Added the "include-media" mixin to the body colour class, fixing the generating of the CSS.
 
 ### Security
+
 - Updating dependencies to prevent vulnerabilities.
 - General testing to ensure compatibility with latest WordPress version (5.4).
 - General testing to ensure compatibility with latest LSX Theme version (2.7).
 
-
 ## [[1.3.2]](https://github.com/lightspeeddevelopment/lsx-customizer/releases/tag/1.3.2) - 2019-11-13
 
 ### Fixed
-* Fix - Fixing the `woocommerce_get_page_id is deprecated since version 3.0! Use wc_get_page_id instead.` error.
-* Fix - Fixing the `WC_Cart::get_cart_url is deprecated since version 2.5! Use wc_get_cart_url instead.` error.
-* Fix - Fixing the placeholders for the widgets.
 
+- Fix - Fixing the `woocommerce_get_page_id is deprecated since version 3.0! Use wc_get_page_id instead.` error.
+- Fix - Fixing the `WC_Cart::get_cart_url is deprecated since version 2.5! Use wc_get_cart_url instead.` error.
+- Fix - Fixing the placeholders for the widgets.
 
 ## [[1.3.1]](https://github.com/lightspeeddevelopment/lsx-customizer/releases/tag/1.3.1) - 2019-08-21
 
 ### Added
+
 - Added in Repeat option for background in login screen options.
 
 ### Fixed
-- Set background size to initial[None] as default
 
+- Set background size to initial[None] as default
 
 ## [[1.3.0]](https://github.com/lightspeeddevelopment/lsx-customizer/releases/tag/1.3.0) - 2019-08-06
 
 ### Added
+
 - Adding logging screen options.
 - Added in the logo control.
 - Adding classes methods.
 
 ### Fixed
+
 - More default styling.
 - Adjust box shadow colors.
 - Coding Standard fixes.
 
-
 ## [[1.2.2]](https://github.com/lightspeeddevelopment/lsx-customizer/releases/tag/1.2.2) - 2018-04-09
 
 ### Added
+
 - Update the SCSS 2 CSS Vendor (http://leafo.github.io/scssphp/).
 
 ### Fixed
-- Making sure the Thank You page does not redirect when you land on the page.
 
+- Making sure the Thank You page does not redirect when you land on the page.
 
 ## [[1.2.1]]()
 
 ### Deprecated
-- Removed the API Class.
 
+- Removed the API Class.
 
 ## [[1.2.0]]()
 
 ### Added
+
 - WooCommerce checkout layout.
 - WooCommerce checkout steps.
 - WooCommerce checkout custom thank you page.
@@ -88,50 +101,53 @@
 - Add Sensei compatibility.
 
 ### Fixed
-- Extra menu items for logout users / Compatibility with LSX Login.
 
+- Extra menu items for logout users / Compatibility with LSX Login.
 
 ## [[1.1.0]]()
 
 ### Added
+
 - Added compatibility with LSX 2.0.
 - New project structure.
 - UIX copied from TO 1.1 + Fixed issue with sub tabs click (settings).
 - New option: disable theme credit.
 
 ### Fixed
+
 - Fixed scripts/styles loading order.
 - Fixed small issues.
-
 
 ## [[1.0.3]]()
 
 ### Changed
+
 - Moved all blog customizer options to LSX Blog Customizer plugin.
 
 ### Fixed
+
 - Added filters to send the custom colours to custom selectors.
 - Adjusted the plugin settings link inside the LSX API Class.
 - Fixed buttons (default and CTA) selectors (hover, active, focus, visited).
 
-
 ## [[1.0.2]]()
 
 ### Fixed
-- Fixed all prefixes replaces (to_ > lsx_to_, TO_ > LSX_TO_).
 
+- Fixed all prefixes replaces (to* > lsx_to*, TO* > LSX_TO*).
 
 ## [[1.0.1]]()
 
 ### Fixed
+
 - Added a extra style selector for main menu CSS: item active + hover.
 - Avoided use a return function inside the PHP function "empty" (compatibility with PHP 5.5 and lower).
 - Compatibility with WPML 3.6.
 - Reduced the access to server (check API key status) using transients.
 - Made the API URLs dev/live dynamic using a prefix "dev-" in the API KEY.
 
-
 ## [[1.0.0]]()
 
 ### Added
+
 - First Version

--- a/classes/class-lsx-customizer-woocommerce.php
+++ b/classes/class-lsx-customizer-woocommerce.php
@@ -47,9 +47,9 @@ if ( ! class_exists( 'LSX_Customizer_WooCommerce' ) ) {
 			 */
 
 			$wp_customize->add_section( 'lsx-wc-checkout' , array(
-				'title'       => esc_html__( 'Checkout', 'lsx-customizer' ),
+				'title'       => esc_html__( 'LSX Checkout', 'lsx-customizer' ),
 				'description' => esc_html__( 'Change the WooCommerce checkout settings.', 'lsx-customizer' ),
-				'panel'       => 'lsx-wc',
+				'panel'       => 'woocommerce',
 				'priority'    => 3,
 			) );
 
@@ -186,9 +186,9 @@ if ( ! class_exists( 'LSX_Customizer_WooCommerce' ) ) {
 			 */
 
 			$wp_customize->add_section( 'lsx-wc-my-account' , array(
-				'title'       => esc_html__( 'My Account', 'lsx-customizer' ),
+				'title'       => esc_html__( 'LSX My Account', 'lsx-customizer' ),
 				'description' => esc_html__( 'Change the WooCommerce My Account settings.', 'lsx-customizer' ),
-				'panel'       => 'lsx-wc',
+				'panel'       => 'woocommerce',
 				'priority'    => 4,
 			) );
 


### PR DESCRIPTION
### Description of the Change

I have changed the functions that call these tabs, so the panel where they show is the same Woocommerce panel.
Also I have added the 'LSX' on the title of all LSX related tabs so they can distinct from the original WC tabs (some of them have the same name)

### Benefits

Tabs will look more organized and not duplicated.

### Verification Process

- I have tested and checked error logs to make sure my changes are not generating errors.
- I have tested that all the tabs are still working on the new place.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx/issues/387

### Changelog Entry

- Merged two WooCommerce panels within the customizer sidebar.
